### PR TITLE
Fix linting issues for release

### DIFF
--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -5,8 +5,8 @@ and functionality areas.
 """
 
 # Import specific functions that are used by the GUI
-from .main_handlers import *
-from .child_handlers import *
+from .child_handlers import *  # noqa: F403
+from .main_handlers import *  # noqa: F403
 from .main_handlers import _unsaved_changes
 
 __all__ = [

--- a/app/handlers/teacher_handlers.py
+++ b/app/handlers/teacher_handlers.py
@@ -36,7 +36,7 @@ def _setup_teacher_dialog_translations(dialog: QWidget) -> None:
     Args:
         dialog: Teacher dialog widget
     """
-    from PySide6.QtWidgets import QCheckBox, QLabel, QPushButton
+    from PySide6.QtWidgets import QLabel, QPushButton
 
     # Update button text
     add_slot_btn = dialog.findChild(QPushButton, "buttonAddSlot")


### PR DESCRIPTION
Fix linting issues that are blocking the 0.1.0 release:

- Remove unused QCheckBox import from teacher_handlers.py
- Fix import sorting in handlers module  
- Suppress F403 warnings for intentional star imports in handlers/__init__.py

This enables the release workflow to proceed successfully.