### PR TITLE
Fix startup crash on missing settings handler import

### DIFF
--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -8,6 +8,7 @@ and functionality areas.
 from .child_handlers import *  # noqa: F403
 from .main_handlers import *  # noqa: F403
 from .main_handlers import _unsaved_changes
+from .settings_handlers import *  # noqa: F403
 
 __all__ = [
     # Re-export all imported functions for backward compatibility


### PR DESCRIPTION
## Summary
- Fixed AttributeError crash on startup by importing settings_handlers module
- Application was failing to start due to missing `settings_load_paths_into_ui` function
- Added missing import in `app/handlers/__init__.py`

## Test plan
- [x] Application starts successfully without crashing
- [x] Settings functionality accessible
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)